### PR TITLE
Add a warmup phase to AnsibleWisdomExperimentRunner

### DIFF
--- a/ghz_frontend.py
+++ b/ghz_frontend.py
@@ -84,6 +84,7 @@ class Config(Base):
         self.__parse_storage_config()
         self.__parse_command_config()
         self.__parse_test_conditions()
+        self.warmup = self.config.get("warmup")
 
     @deprecation.deprecated()
     def get_complete_config(self):
@@ -175,7 +176,14 @@ class Config(Base):
         Returns a dictionary of the dataset configuration.
         """
         return self.input_dataset
+    
 
+    def get_warmup(self):
+        """
+        Returns boolean, whether warm up is enabled
+        """
+        return self.warmup
+    
     def get_test_conditions(self):
         """
         Returns a dictionary of the test condition metadata
@@ -285,6 +293,8 @@ class GhzRunner(CommandRunner, Base):
         self.test_output = super()._json_load("./temp.json")
         self.test_output["start_time"] = start_time
         self.test_output["end_time"] = end_time
+        self.test_output["prompt"] = self.query
+        self.test_output["context"] = self.context
 
         result = super()._json_load("./temp.json")
         self.test_metadata["date"] = result.get("date")
@@ -344,13 +354,14 @@ class AnsibleWisdomExperimentRunner(Base):
     """
     """
 
-    def __init__(self, storage_config, command_config, input_dataset, test_conditions):
+    def __init__(self, storage_config, command_config, input_dataset, test_conditions, warmup):
         """
         """
         # do we need an abstraction layer here?
         self.storage_config = storage_config
         self.command_config = command_config
         self.test_conditions = test_conditions
+        self.warmup = warmup
 
         self.ghz_instance = GhzRunner(
             params={
@@ -397,13 +408,26 @@ class AnsibleWisdomExperimentRunner(Base):
         base_path = self.storage_config.get("s3_result_path")
         path = f"{base_path}/{date_day}"
         return path
+    
+    def upload_to_s3(self, obj, metadata):
+            path = self.s3_result_path()
+            s3_json_obj_name = "{}-ghz-results.json".format(str(uuid.uuid4()))
+            self.storage.upload_object_with_metadata(
+                body=json.dumps(obj),
+                object_name=f"{path}/{s3_json_obj_name}",
+                metadata=metadata
+            )
 
-    def run(self):
-        """
-        """
+            obj_content = self.storage.retrieve_object_body(f"{path}/{s3_json_obj_name}")
+            obj_metadata = self.storage.retrieve_object_metadata(f"{path}/{s3_json_obj_name}")
+            print("#################")
+            print(f'Object body: {obj_content}')
+            print("#################")
+            print(f'Object metadata: {obj_metadata.get("Metadata")}')
+
+    def run_tests(self, save_output=True):
         dataset = self.dataset_gen.get_dataset()
         for query in dataset:
-            print("#################")
             print(f"###### Running GRPCURL/GHZ with query: \n{query}")
             self.grpcurl_instance.set_input(query.get("prompt"), query.get("context"))
             self.grpcurl_instance.run()
@@ -421,25 +445,34 @@ class AnsibleWisdomExperimentRunner(Base):
 
             output_obj["output_tokens"] = f"{output_tokens}"
             test_metadata["output_tokens"] = f"{output_tokens}"
-
+            
             # TODO delete this local copy?
             start_time = test_metadata.get("start_time")
-            super()._json_dump(output_obj, f"ghz-test-{start_time}-.json")
+            super()._json_dump(output_obj, f"ghz-test-{start_time}.json")
+           
+            if save_output:
+                self.upload_to_s3(output_obj, test_metadata)
 
-            path = self.s3_result_path()
-            s3_json_obj = "{}-ghz-results.json".format(str(uuid.uuid4()))
-            self.storage.upload_object_with_metadata(
-                body=json.dumps(output_obj),
-                object_name=f"{path}/{s3_json_obj}",
-                metadata=test_metadata
-            )
 
-            obj_content = self.storage.retrieve_object_body(f"{path}/{s3_json_obj}")
-            obj_metadata = self.storage.retrieve_object_metadata(f"{path}/{s3_json_obj}")
-            print("#################")
-            print(f'Object body: {obj_content}')
-            print("#################")
-            print(f'Object metadata: {obj_metadata.get("Metadata")}')
+    def run(self):
+        """
+        """
+        if self.warmup:
+            save_concurrency = self.ghz_instance.ghz_concurrency
+            save_requests = self.ghz_instance.total_requests
+            # fill the queues but avoid overload errors 
+            self.ghz_instance.ghz_concurrency = 4*self.ghz_instance.ghz_concurrency
+            self.ghz_instance.total_requests = 256
+
+            print("############ DOING WARMUP RUNS ##############")
+            self.run_tests(save_output=False)
+            self.ghz_instance.ghz_concurrency = save_concurrency
+            self.ghz_instance.total_requests = save_requests
+        
+        print("############ WARMUP PHASE COMPLETE ##############")
+        print("############  RUNNING LOAD TESTS   ##############")
+        self.run_tests(save_output=True)
+        
 
 
 class GHZDemo():
@@ -525,6 +558,7 @@ def main():
             storage_config=config.get_storage_config(),
             command_config=config.get_command_config(),
             input_dataset=config.get_input_dataset(),
+            warmup=config.get_warmup(),
             test_conditions=config.get_test_conditions(),
         )
         test.run()


### PR DESCRIPTION
This PR adds a boolean parameter to the AnsibleWisdomExperimentRunner to enable/disable warmup. If enabled, we will do a full run through the input dataset as a warmup, with concurrency set to 4x the experiment concurrency from the config file (to load the queues). It will not save the results of the warmup run to S3. 

Resolves: Issue https://github.com/openshift-psap/llm-load-test/issues/1