### PR TITLE
Track output tokens before test duration timeout and update throughput accordingly

### DIFF
--- a/load_test.py
+++ b/load_test.py
@@ -173,6 +173,7 @@ def main(args):
                 plugin=plugin,
                 logger_q=logger_q,
                 log_level=args.log_level,
+                run_duration=duration,
             )
             proc = mp_ctx.Process(target=user.run_user_process)
             procs.append(proc)

--- a/plugins/caikit_client_plugin.py
+++ b/plugins/caikit_client_plugin.py
@@ -58,7 +58,7 @@ class CaikitClientPlugin(plugin.Plugin):
         else:
             logger.error("Interface %s not yet implemented", args["interface"])
 
-    def request_grpc(self, query, user_id):
+    def request_grpc(self, query, user_id, test_end_time: float=0):
         grpc_client = GrpcClient(self.host, self.port, verify=False)
 
         result = RequestResult(user_id, query.get("input_id"), query.get("input_tokens"))
@@ -76,12 +76,13 @@ class CaikitClientPlugin(plugin.Plugin):
         result.end_time = time.time()
 
         result.output_tokens = query["output_tokens"]
+        result.output_tokens_before_timeout = result.output_tokens
         result.output_text = response
 
         result.calculate_results()
         return result
 
-    def streaming_request_grpc(self, query, user_id):
+    def streaming_request_grpc(self, query, user_id, test_end_time: float=0):
         grpc_client = GrpcClient(self.host, self.port, verify=False)
 
         result = RequestResult(user_id, query.get("input_id"), query.get("input_tokens"))
@@ -109,6 +110,9 @@ class CaikitClientPlugin(plugin.Plugin):
         result.output_text = "".join(tokens)
         result.output_tokens = len(tokens)
 
+        # TODO: Calculate correct output tokens before test timeout duration for streaming requests
+        result.output_tokens_before_timeout = result.output_tokens
+
         result.calculate_results()
 
         return result
@@ -131,6 +135,7 @@ class CaikitClientPlugin(plugin.Plugin):
         result.end_time = time.time()
 
         result.output_tokens = query["output_tokens"]
+        result.output_tokens_before_timeout = result.output_tokens
         result.output_text = response
 
         result.calculate_results()
@@ -163,6 +168,8 @@ class CaikitClientPlugin(plugin.Plugin):
 
         result.output_text = "".join(tokens)
         result.output_tokens = len(tokens)
+        # TODO: Calculate correct output tokens before test timeout duration for streaming requests
+        result.output_tokens_before_timeout = result.output_tokens
 
         result.calculate_results()
         return result

--- a/plugins/dummy_plugin.py
+++ b/plugins/dummy_plugin.py
@@ -22,13 +22,14 @@ class DummyPlugin(plugin.Plugin):
         else:
             self.request_func = self.request_http
 
-    def request_http(self, query, user_id):
+    def request_http(self, query, user_id, test_end_time: float=0):
         result = RequestResult(user_id, query.get("input_id"), query.get("input_tokens"))
         result.start_time = time.time()
 
         # Fake response is just the input backwards
         result.output_text = query.get("text")[::-1]
         result.output_tokens = query["output_tokens"]
+        result.output_tokens_before_timeout = result.output_tokens
 
         time.sleep(1)
 
@@ -38,7 +39,7 @@ class DummyPlugin(plugin.Plugin):
 
         return result
 
-    def streaming_request_http(self, query, user_id):
+    def streaming_request_http(self, query, user_id, test_end_time: float=0):
         result = RequestResult(user_id, query.get("input_id"), query.get("input_tokens"))
         result.start_time = time.time()
         time.sleep(0.1)
@@ -58,6 +59,9 @@ class DummyPlugin(plugin.Plugin):
         result.end_time = time.time()
         result.output_text = "".join(tokens)
         result.output_tokens = len(tokens)
+
+        # TODO: Calculate correct output tokens before test timeout duration for streaming requests
+        result.output_tokens_before_timeout = result.output_tokens
 
         result.calculate_results()
         return result

--- a/plugins/hf_tgi_plugin.py
+++ b/plugins/hf_tgi_plugin.py
@@ -35,7 +35,7 @@ class HFTGIPlugin(plugin.Plugin):
 
         self.host = args["host"] + endpoint
 
-    def streaming_request_http(self, query, user_id):
+    def streaming_request_http(self, query, user_id, test_end_time: float=0):
 
         headers = {"Content-Type": "application/json"}
 
@@ -112,6 +112,9 @@ class HFTGIPlugin(plugin.Plugin):
         result.end_time = time.time()
         result.output_text = "".join(tokens)
         result.output_tokens = len(tokens)
+
+        # TODO: Calculate correct output tokens before test timeout duration for streaming requests
+        result.output_tokens_before_timeout = result.output_tokens
 
         result.calculate_results()
         return result

--- a/plugins/text_generation_webui_plugin.py
+++ b/plugins/text_generation_webui_plugin.py
@@ -43,7 +43,7 @@ class TextGenerationWebUIPlugin(plugin.Plugin):
 
         self.host = args["host"]
 
-    def streaming_request_http(self, query, user_id):
+    def streaming_request_http(self, query, user_id, test_end_time: float=0):
         headers = {"Content-Type": "application/json"}
 
         data = {
@@ -94,6 +94,9 @@ class TextGenerationWebUIPlugin(plugin.Plugin):
         result.end_time = time.time()
         result.output_text = "".join(tokens)
         result.output_tokens = len(tokens)
+
+        # TODO: Calculate correct output tokens before test timeout duration for streaming requests
+        result.output_tokens_before_timeout = result.output_tokens
 
         result.calculate_results()
         return result

--- a/result.py
+++ b/result.py
@@ -5,6 +5,7 @@ class RequestResult:
         self.input_tokens = input_tokens
         self.output_text = None
         self.output_tokens = None
+        self.output_tokens_before_timeout = None
         self.start_time = None
         self.ack_time = None
         self.first_token_time = None


### PR DESCRIPTION
Fixes issue #37 

Summary:
- Calculate throughput based on the total number of tokens received across all the users only within the duration of the test.
- Once the test duration timeout hits we record the total token counts received so far in `output_tokens_before_timeout` but let the requests complete.
- Aggregate the summary `tpot`, `ttft`, `itl`, `tt_ack` only on the requests that were completed within the duration of the test.
- Following additional information about the run is included in the summary statistics
    - `true_throughput`: Total true throughput across all users not bounded by the test duration (this is the current throughput value)
    - `req_completed_within_test_duration`: Total requests that were completed within the test duration (This is not the total request that we sent during the test duration)
    - `output_tokens_before_timeout`: Token count received before we hit the test timeout.

Output json
```
{
  "results": [
    {
      "user_id": 0,
      "input_id": 1381,
      "input_tokens": 631,
      "output_text": <>,
      "output_tokens": 807,
      "output_tokens_before_timeout": 807,
      "start_time": 1710828808.060118,
      "ack_time": 1710828808.190614,
      "first_token_time": 1710828809.27596,
      "end_time": 1710828832.663594,
      "response_time": 24603.47604751587,
      "tt_ack": 130.49602508544922,
      "ttft": 1215.8420085906982,
      "itl": 29.016915681048598,
      "tpot": 30.487578745372826,
      "stop_reason": 1,
      "error_code": null,
      "error_text": null
    },
    {
      "user_id": 0,
      "input_id": 367,
      "input_tokens": 93,
      "output_text": <>,
      "output_tokens": 415,
      "output_tokens_before_timeout": 247,
      "start_time": 1710828808.061833,
      "ack_time": 1710828808.2319958,
      "first_token_time": 1710828809.771811,
      "end_time": 1710828822.54969,
      "response_time": 14487.857103347778,
      "tt_ack": 170.16291618347168,
      "ttft": 1709.9781036376953,
      "itl": 30.864442028285225,
      "tpot": 34.91049904421151,
      "stop_reason": 1,
      "error_code": null,
      "error_text": null
    },
    {
      "user_id": 1,
      "input_id": 697,
      "input_tokens": 240,
      "output_text": <>,
      "output_tokens": 51,
      "output_tokens_before_timeout": 51,
      "start_time": 1710828808.0637498,
      "ack_time": 1710828808.2321742,
      "first_token_time": 1710828808.305013,
      "end_time": 1710828813.435929,
      "response_time": 5372.179269790649,
      "tt_ack": 168.4243679046631,
      "ttft": 241.26315116882324,
      "itl": 39.4685855278602,
      "tpot": 41.0090020594706,
      "stop_reason": 1,
      "error_code": null,
      "error_text": null
    },
    {
      "user_id": 1,
      "input_id": 2283,
      "input_tokens": 1726,
      "output_text": <>,
      "output_tokens": 240,
      "output_tokens_before_timeout": 131,
      "start_time": 1710828813.4369159,
      "ack_time": 1710828813.5709372,
      "first_token_time": 1710828814.246189,
      "end_time": 1710828815.5932941,
      "response_time": 2156.3782691955566,
      "tt_ack": 134.02128219604492,
      "ttft": 809.2732429504395,
      "itl": 26.942100524902344,
      "tpot": 42.2819268469717,
      "stop_reason": 1,
      "error_code": null,
      "error_text": null
    },
    {
      "user_id": 2,
      "input_id": 1893,
      "input_tokens": 1122,
      "output_text": <>,
      "output_tokens": 408,
      "output_tokens_before_timeout": 77,
      "start_time": 1710828815.5943859,
      "ack_time": 1710828815.728322,
      "first_token_time": 1710828815.980874,
      "end_time": 1710828826.969864,
      "response_time": 11375.478029251099,
      "tt_ack": 133.93616676330566,
      "ttft": 386.4881992340088,
      "itl": 26.999975012327003,
      "tpot": 27.881073601105633,
      "stop_reason": 1,
      "error_code": null,
      "error_text": null
    },
   ....
   ....
  ],
  "config": {
    "output": {
      "format": "json",
      "dir": "./output/",
      "file": "output.json"
    },
    "warmup": false,
    "warmup_options": {
      "requests": 11,
      "timeout_sec": 200
    },
    "storage": {
      "type": "local"
    },
    "dataset": {
      "file": "datasets/openorca_large_subset_011.jsonl",
      "max_queries": 1000,
      "min_input_tokens": 0,
      "max_input_tokens": 2048,
      "max_output_tokens": 1024,
      "max_sequence_tokens": 2048
    },
    "load_options": {
      "type": "constant",
      "concurrency": 8,
      "duration": 20
    },
    "plugin": "tgis_grpc_plugin",
    "plugin_options": {
      "streaming": true,
      "model_name": "flan-t5-xxl",
      "host": "localhost",
      "port": 8033
    },
    "extra_metadata": {
      "replicas": 1
    }
  },
  "summary": {
    "tpot": {
      "min": 33.801718386347424,
      "max": 50.18879237927889,
      "median": 41.64546445322115,
      "mean": 42.3619508825109,
      "percentile_80": 45.968945295202964,
      "percentile_90": 47.57589627253382,
      "percentile_95": 48.88234432590635,
      "percentile_99": 49.92750276860438
    },
    "ttft": {
      "min": 212.9042148590088,
      "max": 1210.4179859161377,
      "median": 715.1448726654053,
      "mean": 617.9029643535614,
      "percentile_80": 800.5616188049316,
      "percentile_90": 929.6166658401488,
      "percentile_95": 1070.017325878143,
      "percentile_99": 1182.3378539085388
    },
    "itl": {
      "min": 26.942100524902344,
      "max": 41.11137866973877,
      "median": 33.72192682736652,
      "mean": 33.376300171496645,
      "percentile_80": 37.8796567007482,
      "percentile_90": 39.96142347042377,
      "percentile_95": 40.53640107008127,
      "percentile_99": 40.99638314980727
    },
    "tt_ack": {
      "min": 132.3409080505371,
      "max": 170.15504837036133,
      "median": 135.48719882965088,
      "mean": 146.83520793914795,
      "percentile_80": 167.6858425140381,
      "percentile_90": 168.94357204437256,
      "percentile_95": 169.54931020736694,
      "percentile_99": 170.03390073776245
    },
    "response_time": {
      "min": 1486.5946769714355,
      "max": 24603.47604751587,
      "median": 8485.796213150024,
      "mean": 9834.608062108358,
      "percentile_80": 17455.81111907959,
      "percentile_90": 18509.19895172119,
      "percentile_95": 20452.119684219353,
      "percentile_99": 23773.204774856564
    },
    "output_tokens": {
      "min": 32,
      "max": 807,
      "median": 218.0,
      "mean": 308.46666666666664,
      "percentile_80": 563.6000000000001,
      "percentile_90": 672.1999999999999,
      "percentile_95": 728.5999999999999,
      "percentile_99": 791.3199999999999
    },
    "output_tokens_before_timeout": {
      "min": 32,
      "max": 274,
      "median": 131.0,
      "mean": 140.4,
      "percentile_80": 224.60000000000002,
      "percentile_90": 256.6,
      "percentile_95": 266.3,
      "percentile_99": 272.46
    },
    "input_tokens": {
      "min": 63,
      "max": 1838,
      "median": 504.0,
      "mean": 699.4,
      "percentile_80": 1133.4,
      "percentile_90": 1507.1999999999998,
      "percentile_95": 1759.6,
      "percentile_99": 1822.32
    },
    "true_throughput": 170.30448425410233,
    "total_duration": 27.16898512840271,
    "throughput": 210.6,
    "total_requests": 15,
    "req_completed_within_test_duration": 10,
    "total_failures": 0,
    "failure_rate": 0.0
  }
}
```