### PR TITLE
feat: include vllm plugin

### DIFF
--- a/plugins/vllm_plugin.py
+++ b/plugins/vllm_plugin.py
@@ -1,0 +1,117 @@
+import json
+import logging
+import time
+
+import requests
+import urllib3
+
+from plugins import plugin
+from result import RequestResult
+
+urllib3.disable_warnings()
+
+required_args = ["host", "model_name"]
+
+logger = logging.getLogger("user")
+
+"""
+Example plugin config.yaml:
+
+plugin: "vllm_plugin"
+plugin_options:
+  interface: "http"
+  streaming: True
+  model_name: "Llama-2-7b-hf"
+  host: "http://myhost"
+  port: 80
+"""
+
+# TODO:
+# - Add configurable timeout for requests
+class VLLMPlugin(plugin.Plugin):
+    def __init__(self, args):
+        self._parse_args(args)
+
+    def _parse_args(self, args):
+        for arg in required_args:
+            if arg not in args:
+                logger.error("Missing plugin arg: %s", arg)
+
+        endpoint = "/v1/completions"
+        self.request_func = self.request_http
+        self.host = args["host"] + endpoint
+        self.model_name = args["model_name"]
+
+    def request_http(self, query, user_id, test_end_time: float=0):
+
+        headers = {"Content-Type": "application/json"}
+
+        data = {
+            "prompt": query["text"],
+            "model": self.model_name,
+            "max_tokens": 700,
+            "temperature": 0,
+            "stream": "True"
+        }
+
+        result = RequestResult(user_id, query.get("input_id"), query.get("input_tokens"))
+
+        tokens = []
+        result.start_time = time.time()
+        response = None
+        try:
+            response = requests.post(
+                self.host, headers=headers, json=data, verify=False, stream=True
+            )
+            response.raise_for_status()
+        except requests.exceptions.ConnectionError as err:
+            result.end_time = time.time()
+            result.error_text = repr(err)
+            if response is not None:
+                result.error_code = response.status_code
+            return result
+        except requests.exceptions.HTTPError as err:
+            result.end_time = time.time()
+            result.error_text = repr(err)
+            if response is not None:
+                result.error_code = response.status_code
+            return result
+
+        logger.debug("response: %s", response)
+        for line in response.iter_lines():
+            _, found, data = line.partition(b"data:")
+            if found:
+                try:
+                    message = json.loads(data)
+                    error = message.get("error")
+                    if error is None:
+                        token = message["choices"][0]["text"]
+                        logger.debug("Token: %s", token)
+                    else:
+                        result.error_code = response.status_code
+                        result.error_text = error
+                        logger.error("Error received in response message: %s", error)
+                        break
+                except json.JSONDecodeError:
+                    logger.error("response line could not be json decoded: %s", line)
+                    continue
+                except KeyError:
+                    logger.error(
+                        "KeyError, unexpected response format in line: %s", line
+                    )
+                    continue
+            else:
+                continue
+
+            tokens.append(token)
+
+        # Response received, return
+        result.end_time = time.time()
+        result.output_text = "".join(tokens)
+        result.output_tokens = len(tokens)
+
+        # TODO: Calculate correct output tokens before test timeout duration for streaming requests
+        result.output_tokens_before_timeout = result.output_tokens
+
+        result.calculate_results()
+        return result

--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,7 @@ from plugins import (
     caikit_client_plugin,
     dummy_plugin,
     hf_tgi_plugin,
+    vllm_plugin,
     text_generation_webui_plugin,
     tgis_grpc_plugin,
 )
@@ -79,6 +80,8 @@ def parse_config(config):
         plugin = tgis_grpc_plugin.TGISGRPCPlugin(config.get("plugin_options"))
     elif plugin_type == "hf_tgi_plugin":
         plugin = hf_tgi_plugin.HFTGIPlugin(config.get("plugin_options"))
+    elif plugin_type == "vllm_plugin":
+        plugin = vllm_plugin.VLLMPlugin(config.get("plugin_options"))
     elif plugin_type == "dummy_plugin":
         plugin = dummy_plugin.DummyPlugin(config.get("plugin_options"))
     else:


### PR DESCRIPTION
Some initial testing:
config.yml
```
plugin: "vllm_plugin"
plugin_options:
  #interface: "http" # "grpc" # Some plugins like caikit-nlp-client should support grpc/http
  streaming: True
  model_name: "mistralai/Mistral-7B-Instruct-v0.2" # "flan-t5-small"
  host: "http://vllm-ccamacho-test.apps.psap.example.com" # "route.to.host"
  port: 80 # 8033
```

Output
```
ccamacho@guateque:~/dev/llm-load-test$ python3 load_test.py -c config.yaml

2024-04-14 00:36:11,601 INFO     root MainProcess dataset config: {'file': 'datasets/openorca_large_subset_011.jsonl', 'max_queries': 1000, 'min_input_tokens': 0, 'max_input_tokens': 1024, 'max_output_tokens': 256, 'max_sequence_tokens': 1024}

2024-04-14 00:36:11,602 INFO     root MainProcess load_options config: {'type': 'constant', 'concurrency': 1, 'duration': 10}

2024-04-14 00:36:11,602 INFO     root MainProcess Initializing dataset with {'self': <dataset.Dataset object at 0x76763c7a9b70>, 'file': 'datasets/openorca_large_subset_011.jsonl', 'model_name': 'mistralai/Mistral-7B-Instruct-v0.2', 'max_queries': 1000, 'min_input_tokens': 0, 'max_input_tokens': 1024, 'min_output_tokens': 0, 'max_output_tokens': 256, 'max_sequence_tokens': 1024}
.
.
.
2024-04-14 00:36:13,869 INFO     user SpawnProcess-1 User 0 making request
2024-04-14 00:36:13,964 INFO     root MainProcess Adding 1 entries to dataset queue
2024-04-14 00:36:15,755 ERROR    user SpawnProcess-1 response line could not be json decoded: b'data: [DONE]'
2024-04-14 00:36:15,756 INFO     user SpawnProcess-1 User 0 making request
2024-04-14 00:36:15,787 INFO     root MainProcess Adding 1 entries to dataset queue
2024-04-14 00:36:17,866 ERROR    user SpawnProcess-1 response line could not be json decoded: b'data: [DONE]'
2024-04-14 00:36:17,866 INFO     user SpawnProcess-1 User 0 making request
2024-04-14 00:36:17,910 INFO     root MainProcess Adding 1 entries to dataset queue
2024-04-14 00:36:19,323 ERROR    user SpawnProcess-1 response line could not be json decoded: b'data: [DONE]'
2024-04-14 00:36:19,324 INFO     user SpawnProcess-1 User 0 making request
2024-04-14 00:36:19,347 INFO     root MainProcess Adding 1 entries to dataset queue
2024-04-14 00:36:21,778 INFO     root MainProcess Timer ended, stopping processes
2024-04-14 00:36:24,427 INFO     root MainProcess Writing output to ./output/
2024-04-14 00:36:24,427 INFO     root MainProcess dataset config: {'file': 'datasets/openoca_large_subset_011.jsonl', 'max_queries': 1000, 'min_input_tokens': 0, 'max_input_tokens': 1024, 'max_output_tokens': 256, 'max_sequence_tokens': 1024}
2024-04-14 00:36:24,427 INFO     root MainProcess load_options config: {'type': 'constant', 'concurrency': 1, 'duration': 10}
2024-04-14 00:36:24,427 INFO     root MainProcess Length of results: 5
2024-04-14 00:36:24,426 ERROR    user SpawnProcess-1 response line could not be json decoded: b'data: [DONE]'
   user_id  input_id  input_tokens  \
0        0       708           252   
1        0       697           245   
2        0      1143           524   
3        0      1003           431   
4        0      1455           740   

                                         output_text  output_tokens  \
0   No, the answer is "go to the shop and ask to ...             95   
1  \n\nExplanation:\n\nThe answer is [B]. The rea...            113   
2  \n\nPeter was organizing a trip to the Lake Di...            127   
3  \n\nSix months passed between the final confro...             81   
4  \n\nOne possible question from this paragraph ...            336   

   output_tokens_before_timeout    start_time ack_time first_token_time  \
0                            95  1.713048e+09     None             None   
1                           113  1.713048e+09     None             None   
2                           127  1.713048e+09     None             None   
3                            81  1.713048e+09     None             None   
4                           336  1.713048e+09     None             None   

       end_time  response_time tt_ack  ttft   itl       tpot stop_reason  \
0  1.713048e+09    1688.436508   None  None  None  17.773016        None   
1  1.713048e+09    1886.348248   None  None  None  16.693347        None   
2  1.713048e+09    2109.926224   None  None  None  16.613592        None   
3  1.713048e+09    1456.954002   None  None  None  17.987086        None   
4  1.713048e+09    5102.228165   None  None  None  15.185203        None   

  error_code error_text  
0       None       None  
1       None       None  
2       None       None  
3       None       None  
4       None       None  

---
Full results in output/output.json. Results summary:
Error count: 0 of 5 total requests
tpot                              16.850449
response_time                   2448.778629
output_tokens                    150.400000
output_tokens_before_timeout     150.400000
input_tokens                     438.400000
dtype: float64
/home/ccamacho/.local/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1215: RuntimeWarning: Mean of empty slice
  return np.nanmean(a, axis, out=out, keepdims=keepdims)
/home/ccamacho/.local/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1215: RuntimeWarning: Mean of empty slice
  return np.nanmean(a, axis, out=out, keepdims=keepdims)
/home/ccamacho/.local/lib/python3.10/site-packages/numpy/lib/nanfunctions.py:1215: RuntimeWarning: Mean of empty slice
  return np.nanmean(a, axis, out=out, keepdims=keepdims)
Total true throughput across all users: 61.40549784331384 tokens / sec, for duration 12.246460437774658
Total throughput across all users bounded by the test duration: 75.2 tokens / sec, for duration 10
2024-04-14 00:36:28,428 INFO     user SpawnProcess-1 User 0 done
2024-04-14 00:36:28,548 INFO     root MainProcess User processes terminated succesfully
```