### PR TITLE
fix: handle optional usage field in OpenAI API

### DIFF
--- a/plugins/openai_plugin.py
+++ b/plugins/openai_plugin.py
@@ -224,14 +224,15 @@ class OpenAIPlugin(plugin.Plugin):
 
                 # Last token comes with finish_reason set.
                 if message.get("choices", [])[0].get("finish_reason", None):
-                    result.output_tokens = message["usage"]["completion_tokens"]
-                    result.input_tokens = message["usage"]["prompt_tokens"]
-                    result.stop_reason =  message["choices"][0]["finish_reason"]
+                    if message.get("usage"):
+                        result.output_tokens = message["usage"]["completion_tokens"]
+                        result.input_tokens = message["usage"]["prompt_tokens"]
+                        # If test duration timeout didn't happen before the last token is received, 
+                        # total tokens before the timeout will be equal to the total tokens in the response.
+                        if not result.output_tokens_before_timeout:
+                            result.output_tokens_before_timeout = result.output_tokens
 
-                    # If test duration timeout didn't happen before the last token is received, 
-                    # total tokens before the timeout will be equal to the total tokens in the response.
-                    if not result.output_tokens_before_timeout:
-                        result.output_tokens_before_timeout = result.output_tokens
+                    result.stop_reason =  message["choices"][0]["finish_reason"]
 
             except KeyError:
                 logging.exception("KeyError, unexpected response format in line: %s", line)

--- a/plugins/openai_plugin.py
+++ b/plugins/openai_plugin.py
@@ -223,12 +223,12 @@ class OpenAIPlugin(plugin.Plugin):
                 tokens.append(token)
 
                 # Last token comes with finish_reason set.
-                if message.get("choices", [])[0].get("finish_reason", None):
+                if message.get("choices", [{}])[0].get("finish_reason", None):
                     if message.get("usage"):
                         result.output_tokens = message["usage"]["completion_tokens"]
                         result.input_tokens = message["usage"]["prompt_tokens"]
 
-                    result.stop_reason =  message["choices"][0]["finish_reason"]
+                    result.stop_reason = message.get("choices", [{}])[0].get("finish_reason", None)
 
             except KeyError:
                 logging.exception("KeyError, unexpected response format in line: %s", line)

--- a/plugins/openai_plugin.py
+++ b/plugins/openai_plugin.py
@@ -227,10 +227,6 @@ class OpenAIPlugin(plugin.Plugin):
                     if message.get("usage"):
                         result.output_tokens = message["usage"]["completion_tokens"]
                         result.input_tokens = message["usage"]["prompt_tokens"]
-                        # If test duration timeout didn't happen before the last token is received, 
-                        # total tokens before the timeout will be equal to the total tokens in the response.
-                        if not result.output_tokens_before_timeout:
-                            result.output_tokens_before_timeout = result.output_tokens
 
                     result.stop_reason =  message["choices"][0]["finish_reason"]
 
@@ -248,6 +244,11 @@ class OpenAIPlugin(plugin.Plugin):
         if not result.output_tokens:
             logger.warning("Output token count not found in response, length of token list")
             result.output_tokens = len(tokens)
+
+        # If test duration timeout didn't happen before the last token is received, 
+        # total tokens before the timeout will be equal to the total tokens in the response.
+        if not result.output_tokens_before_timeout:
+            result.output_tokens_before_timeout = result.output_tokens
 
         result.calculate_results()
         return result


### PR DESCRIPTION
The usage field that is returned in the `completion` object is optional and will cause errors in runtimes that do not include it. In particular I noticed this in the runtime that instructlab uses.

[OpenAI API docs for the completion object](https://platform.openai.com/docs/api-reference/completions/object)