### PR TITLE
[plugins/openai_plugins] Properly record input_tokens and output_tokens when streaming

### DIFF
--- a/plugins/openai_plugin.py
+++ b/plugins/openai_plugin.py
@@ -145,7 +145,7 @@ class OpenAIPlugin(plugin.Plugin):
         if self.model_name is not None:
             data["model"] = self.model_name
 
-        result = RequestResult(user_id, query.get("input_id"), query.get("input_tokens"))
+        result = RequestResult(user_id, query.get("input_id"))
 
         tokens = []
         response = None

--- a/result.py
+++ b/result.py
@@ -4,7 +4,7 @@
 class RequestResult:
     """Request result class."""
 
-    def __init__(self, user_id, input_id, input_tokens = None):
+    def __init__(self, user_id, input_id, input_tokens=None):
         """Init method."""
         self.user_id = user_id
         self.input_id = input_id

--- a/result.py
+++ b/result.py
@@ -4,7 +4,7 @@
 class RequestResult:
     """Request result class."""
 
-    def __init__(self, user_id, input_id, input_tokens):
+    def __init__(self, user_id, input_id, input_tokens = None):
         """Init method."""
         self.user_id = user_id
         self.input_id = input_id


### PR DESCRIPTION
The "usage" field is not set by the OpenAI API unless `stream_options.include_usage` is set to true. This PR sets `stream_options.include_usage` in the request and handles the extra output it produces.

~Set to WIP as it has only been tested against upstream vLLM.~ Confirmed working with `quay.io/opendatahub/vllm:stable-3c9b8f7`.