### PR TITLE
Update Chat Template

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@ dataset:
   max_output_tokens: 1024
   max_sequence_tokens: 2048
   format_prompt: False
+  custom_prompt_format: None
 load_options:
   type: constant #Future options: loadgen, stair-step
   concurrency: 1 # can also be a list [1,2,4]

--- a/config.yaml
+++ b/config.yaml
@@ -11,9 +11,9 @@ dataset:
   max_input_tokens: 1024
   min_output_tokens: 0
   max_output_tokens: 1024
-  max_sequence_tokens: 2048
+  max_sequence_tokens: 2048 # system_prompt tokens not counted towards filters
   format_prompt: False
-  custom_prompt_format: None
+  custom_prompt_format: null
 load_options:
   type: constant #Future options: loadgen, stair-step
   concurrency: 1 # can also be a list [1,2,4]

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ dataset:
   min_output_tokens: 0
   max_output_tokens: 1024
   max_sequence_tokens: 2048
+  format_prompt: False
 load_options:
   type: constant #Future options: loadgen, stair-step
   concurrency: 1 # can also be a list [1,2,4]

--- a/dataset.py
+++ b/dataset.py
@@ -12,7 +12,7 @@ class Dataset:
 
     def __init__(self,
                  file,
-                 format_prompt=True,
+                 format_prompt=False,
                  model_name="",
                  max_queries=3000,
                  min_input_tokens=0,
@@ -62,7 +62,7 @@ def initialize_dataset(
     custom_prompt_format=None
 ):
     """Initialize the dataset."""
-    prompt_format = get_format_string(model_name, format_prompt) if not custom_prompt_format else custom_prompt_format
+    prompt_format = get_format_string(model_name, format_prompt, custom_prompt_format)
     if '{system_prompt}' not in prompt_format and '{prompt}' not in prompt_format:
         logging.warning("Prompt template does not contain any of ['{system_prompt}', '{prompt}']")
 
@@ -129,10 +129,15 @@ def filter_token_lengths(input_tokens,
             and sequence_tokens < max_sequence_tokens)
 
 
-def get_format_string(model_name, format_prompt):
+def get_format_string(model_name, format_prompt, custom_prompt_format):
     """Get the format string."""
     if not format_prompt:
+        if custom_prompt_format:
+            raise RuntimeError("Custom Prompt provided with format_prompt = " + str(format_prompt))
         return "{prompt}"
+    
+    if custom_prompt_format:
+        return custom_prompt_format
 
     known_system_prompts = {
         "llama": "<s>[INST] <<SYS>>\n{system_prompt}\n<</SYS>>\n\n{prompt} [/INST]",
@@ -147,4 +152,4 @@ def get_format_string(model_name, format_prompt):
             return fmt_str
 
     logging.info("Using default prompt format model_name: %s", model_name)
-    return "{prompt}"
+    return "{system_prompt}\n\n{prompt}"

--- a/dataset.py
+++ b/dataset.py
@@ -147,4 +147,4 @@ def get_format_string(model_name, format_prompt):
             return fmt_str
 
     logging.info("Using default prompt format model_name: %s", model_name)
-    return "{system_prompt}\n\n{prompt}"
+    return "{prompt}"

--- a/dataset.py
+++ b/dataset.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import random
+import warnings
 
 dataset_seed = 1337
 
@@ -18,7 +19,8 @@ class Dataset:
                  max_input_tokens=16000,
                  min_output_tokens=0,
                  max_output_tokens=4096,
-                 max_sequence_tokens=32000
+                 max_sequence_tokens=32000,
+                 custom_prompt_format=None
                  ):
         """Init method."""
         logging.info("Initializing dataset with %s", locals())
@@ -32,6 +34,7 @@ class Dataset:
                                                 min_output_tokens=min_output_tokens,
                                                 max_output_tokens=max_output_tokens,
                                                 max_sequence_tokens=max_sequence_tokens,
+                                                custom_prompt_format=custom_prompt_format
                                                 )
                              ]
         if len(self.dataset_list) < 4:
@@ -55,10 +58,14 @@ def initialize_dataset(
     max_input_tokens=16000,
     min_output_tokens=0,
     max_output_tokens=4096,
-    max_sequence_tokens=32000
+    max_sequence_tokens=32000,
+    custom_prompt_format=None
 ):
     """Initialize the dataset."""
-    prompt_format = get_format_string(model_name, format_prompt)
+    prompt_format = get_format_string(model_name, format_prompt) if not custom_prompt_format else custom_prompt_format
+    if '{system_prompt}' not in prompt_format and '{prompt}' not in prompt_format:
+        logging.warning("Prompt template does not contain any of ['{system_prompt}', '{prompt}']")
+
     with open(filename, "r", encoding="utf-8") as file:
         total_queries = 0
 


### PR DESCRIPTION
This PR is to update the default chat template (to prompt only) and introduce support for custom prompt formats. 

1. vLLM uses tokenizer provided chat templates in the /v1/chat/completions endpoint. 
2. vLLM does not add anything in the /v1/completions endpoint and allows us to precisely control/filter the sequences sent in the request. This PR now allows us to also use custom prompts via the "custom_prompt_format" field.

This PR fixes #67 