### PR TITLE
Add support for auth token to openai plugin

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,5 +23,6 @@ plugin_options:
   model_name: "flan-t5-small"
   host: "http://route.to.host"
   endpoint: "/v1/completions"
+  authorization: "" # Set if host requires Authorization Token
 extra_metadata:
   replicas: 1

--- a/plugins/openai_plugin.py
+++ b/plugins/openai_plugin.py
@@ -85,6 +85,8 @@ class OpenAIPlugin(plugin.Plugin):
             seed = 42,
         )
 
+        self.authorization = args.get("authorization")
+
     def _process_resp(self, resp: bytes) -> Optional[dict]:
         try:
             _, found, data = resp.partition(b"data: ")
@@ -105,6 +107,9 @@ class OpenAIPlugin(plugin.Plugin):
         result.start_time = time.time()
 
         headers = {"Content-Type": "application/json"}
+        
+        if self.authorization: 
+            headers["Authorization"] = f"Bearer {self.authorization}"
 
         request = {
             "max_tokens": query["output_tokens"],
@@ -179,7 +184,11 @@ class OpenAIPlugin(plugin.Plugin):
 
 
     def streaming_request_http(self, query: dict, user_id: int, test_end_time: float):
+
         headers = {"Content-Type": "application/json"}
+        
+        if self.authorization: 
+            headers["Authorization"] = f"Bearer {self.authorization}"
 
         request = {
             "max_tokens": query["output_tokens"],


### PR DESCRIPTION
RHOAI 2.13+ supports authenticated endpoints. This commit adds the ability to query endpoints that require an auth token to the openai plugin.

Closes: https://github.com/openshift-psap/llm-load-test/issues/62