### PR TITLE
fix(result): Prevent ZeroDivisionError in metric calculation

### DIFF
--- a/src/llm_load_test/result.py
+++ b/src/llm_load_test/result.py
@@ -50,12 +50,14 @@ class RequestResult:
                     self.ttft = 1000 * (
                         self.first_token_time - self.start_time
                     )  # Time to first token in ms
-                if self.end_time is not None and self.output_tokens is not None:
+                # ITL is only meaningful if there are at least 2 tokens.
+                if self.end_time is not None and self.output_tokens is not None and self.output_tokens > 1:
                     self.itl = (1000 * (self.end_time - self.first_token_time)) / (
                         self.output_tokens - 1
                     )  # Inter-token latency in ms. Distinct from TPOT as it excludes the first token time.
 
-            if self.response_time is not None and self.output_tokens is not None:
+            # TPOT is only meaningful if there is at least 1 token.
+            if self.response_time is not None and self.output_tokens is not None and self.output_tokens > 0:
                 self.tpot = (
                     self.response_time / self.output_tokens
                 )  # Time per output token in ms


### PR DESCRIPTION
## Description

This PR addresses a potential `ZeroDivisionError` in the `calculate_results` method within `src/llm_load_test/result.py`. The crash can occur when calculating performance metrics under specific, yet common, edge cases.

### Problem

- **Inter-token latency (`itl`):** The calculation divides by `output_tokens - 1`. This leads to a `ZeroDivisionError` if the model returns exactly 1 token.
- **Time per output token (`tpot`):** The calculation divides by `output_tokens`. This leads to a `ZeroDivisionError` if the model returns 0 tokens (e.g., due to an error, timeout, or content filter).

### Solution

This fix introduces defensive checks to ensure the denominators are valid before performing the division:
- The `itl` calculation is now only performed if `output_tokens > 1`.
- The `tpot` calculation is now only performed if `output_tokens > 0`.

If the conditions are not met, the metric fields (`itl` and `tpot`) retain their initial `None` value. This approach prevents the application from crashing and ensures that summary statistics are not skewed by invalid data points.

This change makes the result calculation more robust for both streaming and non-streaming requests.
